### PR TITLE
Updates the middleware runner to return when the response is done.

### DIFF
--- a/packages/middleware-runner/CHANGELOG.md
+++ b/packages/middleware-runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v3.1.0
+
+The runner function now returns true when `res.headersSent` is true or
+`res.writable` is false. This allows the caller to know the status of the
+response object after the runner has done its job.
+
 ## v3.0.3
 
 - This module is now an ES module and must be imported accordingly.

--- a/packages/middleware-runner/README.md
+++ b/packages/middleware-runner/README.md
@@ -2,25 +2,28 @@
 
 For Node.js versions less than 14 please use the 2.x line of releases.
 
-Toisu! runs middlewares in sequence, waiting for promises from middlwares to resolve (when promises
-are returned) before continuing to the next. This module contains a function which does this
-sequential middleware execution. This logic has been placed in its own module since both `toisu` and
-`toisu-router` use it. Other modules intended to work with Toisu! might also find it useful.
+Toisu! runs middlewares in sequence, waiting for promises from middlwares to
+resolve (when promises are returned) before continuing to the next. This module
+contains a function which does this sequential middleware execution. This logic
+has been placed in its own module since both `toisu` and `toisu-router` use it.
+Other modules intended to work with Toisu! might also find it useful.
 
 ## usage
 
-Middleware may either be a function which runs synchronously, or one that returns a promise. A
-mixture of synchronous and asynchronous functions may be used. Note though, that the runner returns
-a promise and will always resolve asynchronously.
+Middleware may either be a function which runs synchronously, or one that
+returns a promise. A mixture of synchronous and asynchronous functions may be
+used. Note though, that the runner returns a promise and will always resolve
+asynchronously.
 
-With plain old ES2015:
+With plain old promises:
 ```javascript
 import runner from '@toisu/middleware-runner';
 
 // context will be used as the `this` value for middlewares.
 runner.call(context, req, res, middlewares)
-  .then(() => {
-    // Run when either all middlewares have been used, or one called `res.end()`.
+  .then(responding => {
+    // responding is true when either the response headers are sent, or the
+    // response is no longer writable for some reason.
   })
   .catch(err => {
     // Run when a middleware threw.
@@ -32,13 +35,16 @@ With async-await:
 import runner from '@toisu/middleware-runner';
 
 async function example() {
+  let responding;
+
   try {
-    await runner.call(context, req, res, middlwares);
+    responding = await runner.call(context, req, res, middlwares);
   } catch (e) {
     // Handle errors.
     return;
   }
 
-  // When either all middlewares have been used, or one called `res.end()`.
+  // responding is true when either the response headers are sent, or the
+  // response is no longer writable for some reason.
 }
 ```

--- a/packages/middleware-runner/index.js
+++ b/packages/middleware-runner/index.js
@@ -1,9 +1,11 @@
 export default async function runner(req, res, middlewares = []) {
   for (const middleware of middlewares) {
     if (res.headersSent || !res.writable) {
-      return;
+      return true;
     }
 
     await middleware.call(this, req, res);
   }
+
+  return (res.headersSent || !res.writable);
 }

--- a/packages/middleware-runner/test/.eslintrc.json
+++ b/packages/middleware-runner/test/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "env": {
     "mocha": true
+  },
+  "rules": {
+    "max-statements": "off"
   }
 }

--- a/packages/middleware-runner/test/index.test.js
+++ b/packages/middleware-runner/test/index.test.js
@@ -125,4 +125,66 @@ describe('middleware-runner', () => {
     assert.ok(middlewares[0].calledOnce);
     assert.ok(middlewares[1].notCalled);
   });
+
+  it('resolves to true when the response is not writable before any middlewares are executed', async () => {
+    res.writable = false;
+
+    const result = await runner(req, res, middlewares);
+
+    assert.equal(result, true);
+    assert.ok(middlewares[0].notCalled);
+    assert.ok(middlewares[1].notCalled);
+  });
+
+  it('resolves to true when the response is no longer writable', async () => {
+    middlewares[0].callsFake(() => (res.writable = false));
+
+    const result = await runner(req, res, middlewares);
+
+    assert.equal(result, true);
+  });
+
+  it('resolves to true when all middlewares are executed and the response is no longer writable', async () => {
+    deferreds[0].resolve();
+    middlewares[1].callsFake(() => (res.writable = false));
+
+    const result = await runner(req, res, middlewares);
+
+    assert.equal(result, true);
+  });
+
+  it('resolves to true when the response headers were sent before any middlewares are executed', async () => {
+    res.headersSent = true;
+
+    const result = await runner(req, res, middlewares);
+
+    assert.equal(result, true);
+    assert.ok(middlewares[0].notCalled);
+    assert.ok(middlewares[1].notCalled);
+  });
+
+  it('resolves to true when the response headers are sent', async () => {
+    middlewares[0].callsFake(() => (res.headersSent = true));
+
+    const result = await runner(req, res, middlewares);
+
+    assert.equal(result, true);
+  });
+
+  it('resolves to true when all middlewares are executed and the response headers are sent', async () => {
+    middlewares[0].callsFake(() => (res.headersSent = true));
+
+    const result = await runner(req, res, middlewares);
+
+    assert.equal(result, true);
+  });
+
+  it('resolves to false when the respose headers are not sent and the response is still writable', async () => {
+    deferreds[0].resolve();
+    deferreds[1].resolve();
+
+    const result = await runner(req, res, middlewares);
+
+    assert.equal(result, false);
+  });
 });


### PR DESCRIPTION
This allows the Toisu class to avoid the same checks. If it turns out that the check needs to be enhanced later, it can be done in the middleware runner alone.