### PR TITLE
Add exports fields to package files.

### DIFF
--- a/packages/body/package.json
+++ b/packages/body/package.json
@@ -4,6 +4,9 @@
   "description": "Body parsing middleware for Toisu!",
   "main": "index.js",
   "type": "module",
+  "exports": {
+    ".": "./index.js"
+  },
   "scripts": {
     "test": "mocha"
   },

--- a/packages/body/test/index.test.js
+++ b/packages/body/test/index.test.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import Toisu from '@toisu/toisu';
 import supertest from 'supertest';
-import * as toisuBody from '../index.js';
+import * as toisuBody from '@toisu/body';
 
 describe('body', () => {
   it('is an object', () => {

--- a/packages/handlebars/package.json
+++ b/packages/handlebars/package.json
@@ -4,6 +4,9 @@
   "description": "A lightweight handlebars wrapper for Toisu.",
   "main": "index.js",
   "type": "module",
+  "exports": {
+    ".": "./index.js"
+  },
   "repository": "github:qubyte/toisu-monorepo",
   "scripts": {
     "test": "mocha"

--- a/packages/handlebars/test/index.test.js
+++ b/packages/handlebars/test/index.test.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import supertest from 'supertest';
 import Toisu from '@toisu/toisu';
-import handlebars from '../index.js';
+import handlebars from '@toisu/handlebars';
 
 describe.only('handlebars', () => {
   it('is a function', () => {

--- a/packages/middleware-runner/package.json
+++ b/packages/middleware-runner/package.json
@@ -4,6 +4,9 @@
   "description": "The core middleware runner for Toisu!",
   "type": "module",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js"
+  },
   "scripts": {
     "test": "mocha"
   },

--- a/packages/middleware-runner/test/index.test.js
+++ b/packages/middleware-runner/test/index.test.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import Deferred from 'es2015-deferred';
-import runner from '../index.js';
+import runner from '@toisu/middleware-runner';
 
 describe('middleware-runner', () => {
   const sandbox = sinon.createSandbox();

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -4,6 +4,9 @@
   "description": "A routing middleware for Toisu!",
   "main": "index.js",
   "type": "module",
+  "exports": {
+    ".": "./index.js"
+  },
   "scripts": {
     "test": "mocha"
   },

--- a/packages/router/test/integration.test.js
+++ b/packages/router/test/integration.test.js
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import supertest from 'supertest';
 import Toisu from '@toisu/toisu';
-import Router from '../index.js';
+import Router from '@toisu/router';
 
 describe('router', () => {
   const sandbox = sinon.createSandbox();

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -4,6 +4,9 @@
   "description": "A wrapper around serve-static for Toisu!",
   "main": "index.js",
   "type": "module",
+  "exports": {
+    ".": "./index.js"
+  },
   "scripts": {
     "test": "mocha"
   },

--- a/packages/static/test/integration.test.js
+++ b/packages/static/test/integration.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { strict as assert } from 'assert';
 import Toisu from '@toisu/toisu';
-import serveStatic from '../index.js';
+import serveStatic from '@toisu/static';
 import supertest from 'supertest';
 
 const readme = fs.readFileSync(new URL('../README.md', import.meta.url), 'utf8').trim();

--- a/packages/toisu/package.json
+++ b/packages/toisu/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "test": "mocha"
   },
+  "exports": {
+    ".": "./index.js"
+  },
   "files": [],
   "repository": "github:qubyte/toisu-monorepo",
   "author": "Mark S. Everitt",

--- a/packages/toisu/test/index.test.js
+++ b/packages/toisu/test/index.test.js
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import supertest from 'supertest';
-import Toisu from '../index.js';
+import Toisu from '@toisu/toisu';
 
 describe('toisu', () => {
   it('is a function', () => {


### PR DESCRIPTION
Make use of these in tests to use the module name itself for import.

The benefit of doing this is that it adds a guarantee that the correct, public facing module is imported for tests.