### PR TITLE
Factor out WeakMaps for private properties.

### DIFF
--- a/packages/router/lib/router.js
+++ b/packages/router/lib/router.js
@@ -27,23 +27,18 @@ function makeRoute(path, preNormalizedHandlers, options) {
   };
 }
 
-// TODO: Make this a private class initialzer when ESLint supports it.
-const routes = new WeakMap();
-
 export default class Router {
-  constructor() {
-    routes.set(this, []);
-  }
+  #routes = [];
 
   route(path, middlewares, options) {
-    routes.get(this).push(makeRoute(path, middlewares, options));
+    this.#routes.push(makeRoute(path, middlewares, options));
   }
 
   get middleware() {
-    const routerRoutes = routes.get(this);
+    const routes = this.#routes;
 
     return function routerMiddleware(req, res) {
-      for (const route of routerRoutes) {
+      for (const route of routes) {
         const result = route(req);
 
         if (result) {

--- a/packages/toisu/index.js
+++ b/packages/toisu/index.js
@@ -1,25 +1,20 @@
 import runner from '@toisu/middleware-runner';
 
-const stacks = new WeakMap();
-
 export default class Toisu {
-  constructor() {
-    stacks.set(this, []);
-    this.handleError = Toisu.defaultHandleError;
-  }
+  #stack = [];
+
+  handleError = Toisu.defaultHandleError;
 
   use(middleware) {
-    stacks.get(this).push(middleware);
+    this.#stack.push(middleware);
     return this;
   }
 
   get requestHandler() {
-    const stack = stacks.get(this);
-
     return (req, res) => {
       const context = new Map();
 
-      return runner.call(context, req, res, stack)
+      return runner.call(context, req, res, this.#stack)
         .then(() => {
           if (!res.headersSent) {
             res.statusCode = 404;


### PR DESCRIPTION
I've been using `WeakMap` to make _effective_ private properties by using class instances as keys. This works just fine, but all maintained versions of Node now support class private fields, which are the thing I was similating in the first place. This PR replaces the effective private properties with private property syntax.