### PR TITLE
Updates the development dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lerna": "^4.0.0"
       },
       "devDependencies": {
-        "eslint": "^8.0.0-beta.2",
+        "eslint": "^8.0.0-rc.0",
         "eslint-config-qubyte": "^4.1.0"
       }
     },
@@ -2563,9 +2563,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.0.0-beta.2.tgz",
-      "integrity": "sha512-8OogV2pwxeXchidklhU38OY8YecG9t6aQP07gQpRRvRwU+sd6Mgt08tORCyvpmG+MqwmD/HSGCtlz77/4NpUUg==",
+      "version": "8.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.0.0-rc.0.tgz",
+      "integrity": "sha512-lIEcKtIhPmFAPvkX0DMaXYPhCpUgW4yrauE1y/VheEhkVlpe33N9v3KwMFLKiWMyCEBsf/LjZc1Mc790b96SCw==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.0.1",
@@ -9535,9 +9535,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.0.0-beta.2.tgz",
-      "integrity": "sha512-8OogV2pwxeXchidklhU38OY8YecG9t6aQP07gQpRRvRwU+sd6Mgt08tORCyvpmG+MqwmD/HSGCtlz77/4NpUUg==",
+      "version": "8.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.0.0-rc.0.tgz",
+      "integrity": "sha512-lIEcKtIhPmFAPvkX0DMaXYPhCpUgW4yrauE1y/VheEhkVlpe33N9v3KwMFLKiWMyCEBsf/LjZc1Mc790b96SCw==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lerna": "^4.0.0"
   },
   "devDependencies": {
-    "eslint": "^8.0.0-beta.2",
+    "eslint": "^8.0.0-rc.0",
     "eslint-config-qubyte": "^4.1.0"
   }
 }

--- a/packages/body/package-lock.json
+++ b/packages/body/package-lock.json
@@ -6,36 +6,36 @@
   "packages": {
     "": {
       "name": "@toisu/body",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "body": "^5.1.0"
       },
       "devDependencies": {
-        "@toisu/toisu": "^4.0.2",
-        "mocha": "^9.0.3",
-        "supertest": "^6.1.4"
+        "@toisu/toisu": "^4.0.3",
+        "mocha": "^9.1.2",
+        "supertest": "^6.1.6"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@toisu/middleware-runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.3.tgz",
-      "integrity": "sha512-KBiHpqBfynQyZP15f/EcbOrIlre71oo7yiogFyQGyzKk1wzm6R2SyU4dCbgwuYBl9B9ElamRe98lZDUi+jLo7g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.4.tgz",
+      "integrity": "sha512-A+nFnlOQm9a2r9r+ZloAJWXGbtjl0JonrPikXXf9MsdAgsCaSF5nBJd2bmcPYPa+8pmDy0sI/ritZAG5k2k3mA==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@toisu/toisu": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.2.tgz",
-      "integrity": "sha512-tVVekluc0mscXOG4o9hJtHM9khR0gHyu3QKuwFQrWcv8L/3TnFnhWfyy+f3E6uhiubWqo+urimUCZQj/jVMTXw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.3.tgz",
+      "integrity": "sha512-5PEzEQ2Aw10BBXBbtWel1zP5AcCCPn5uCOJQZEMlYO/yFfXngB1UkLi+7+BMcQjxb620XHyxMLQ7gmSiHRSuXA==",
       "dev": true,
       "dependencies": {
-        "@toisu/middleware-runner": "^3.0.3"
+        "@toisu/middleware-runner": "^3.0.4"
       },
       "engines": {
         "node": ">=14"
@@ -54,15 +54,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ansi-styles": {
@@ -347,9 +338,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -669,15 +660,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -836,16 +818,16 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -856,12 +838,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -886,9 +867,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -1137,31 +1118,6 @@
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
       "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
     },
-    "node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1197,9 +1153,9 @@
       }
     },
     "node_modules/supertest": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.4.tgz",
-      "integrity": "sha512-giC9Zm+Bf1CZP09ciPdUyl+XlMAu6rbch79KYiYKOGcbK2R1wH8h+APul1i/3wN6RF1XfWOIF+8X1ga+7SBrug==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.6.tgz",
+      "integrity": "sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==",
       "dev": true,
       "dependencies": {
         "methods": "^1.1.2",
@@ -1255,15 +1211,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/workerpool": {
@@ -1455,18 +1402,18 @@
   },
   "dependencies": {
     "@toisu/middleware-runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.3.tgz",
-      "integrity": "sha512-KBiHpqBfynQyZP15f/EcbOrIlre71oo7yiogFyQGyzKk1wzm6R2SyU4dCbgwuYBl9B9ElamRe98lZDUi+jLo7g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.4.tgz",
+      "integrity": "sha512-A+nFnlOQm9a2r9r+ZloAJWXGbtjl0JonrPikXXf9MsdAgsCaSF5nBJd2bmcPYPa+8pmDy0sI/ritZAG5k2k3mA==",
       "dev": true
     },
     "@toisu/toisu": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.2.tgz",
-      "integrity": "sha512-tVVekluc0mscXOG4o9hJtHM9khR0gHyu3QKuwFQrWcv8L/3TnFnhWfyy+f3E6uhiubWqo+urimUCZQj/jVMTXw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.3.tgz",
+      "integrity": "sha512-5PEzEQ2Aw10BBXBbtWel1zP5AcCCPn5uCOJQZEMlYO/yFfXngB1UkLi+7+BMcQjxb620XHyxMLQ7gmSiHRSuXA==",
       "dev": true,
       "requires": {
-        "@toisu/middleware-runner": "^3.0.3"
+        "@toisu/middleware-runner": "^3.0.4"
       }
     },
     "@ungap/promise-all-settled": {
@@ -1479,12 +1426,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
@@ -1717,9 +1658,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -1948,12 +1889,6 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -2061,16 +1996,16 @@
       }
     },
     "mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -2081,12 +2016,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -2100,9 +2034,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "normalize-path": {
@@ -2276,25 +2210,6 @@
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
       "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
     },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      }
-    },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^3.0.0"
-      }
-    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2321,9 +2236,9 @@
       }
     },
     "supertest": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.4.tgz",
-      "integrity": "sha512-giC9Zm+Bf1CZP09ciPdUyl+XlMAu6rbch79KYiYKOGcbK2R1wH8h+APul1i/3wN6RF1XfWOIF+8X1ga+7SBrug==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.6.tgz",
+      "integrity": "sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==",
       "dev": true,
       "requires": {
         "methods": "^1.1.2",
@@ -2361,15 +2276,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
       }
     },
     "workerpool": {

--- a/packages/body/package.json
+++ b/packages/body/package.json
@@ -29,8 +29,8 @@
   },
   "devDependencies": {
     "@toisu/toisu": "^4.0.3",
-    "mocha": "^9.0.3",
-    "supertest": "^6.1.4"
+    "mocha": "^9.1.2",
+    "supertest": "^6.1.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/handlebars/package-lock.json
+++ b/packages/handlebars/package-lock.json
@@ -6,33 +6,33 @@
   "packages": {
     "": {
       "name": "@toisu/handlebars",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "handlebars": "^4.7.7"
       },
       "devDependencies": {
-        "@toisu/toisu": "^4.0.2",
-        "mocha": "^9.0.3",
+        "@toisu/toisu": "^4.0.3",
+        "mocha": "^9.1.2",
         "supertest": "^6.1.4"
       }
     },
     "node_modules/@toisu/middleware-runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.3.tgz",
-      "integrity": "sha512-KBiHpqBfynQyZP15f/EcbOrIlre71oo7yiogFyQGyzKk1wzm6R2SyU4dCbgwuYBl9B9ElamRe98lZDUi+jLo7g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.4.tgz",
+      "integrity": "sha512-A+nFnlOQm9a2r9r+ZloAJWXGbtjl0JonrPikXXf9MsdAgsCaSF5nBJd2bmcPYPa+8pmDy0sI/ritZAG5k2k3mA==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@toisu/toisu": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.2.tgz",
-      "integrity": "sha512-tVVekluc0mscXOG4o9hJtHM9khR0gHyu3QKuwFQrWcv8L/3TnFnhWfyy+f3E6uhiubWqo+urimUCZQj/jVMTXw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.3.tgz",
+      "integrity": "sha512-5PEzEQ2Aw10BBXBbtWel1zP5AcCCPn5uCOJQZEMlYO/yFfXngB1UkLi+7+BMcQjxb620XHyxMLQ7gmSiHRSuXA==",
       "dev": true,
       "dependencies": {
-        "@toisu/middleware-runner": "^3.0.3"
+        "@toisu/middleware-runner": "^3.0.4"
       },
       "engines": {
         "node": ">=14"
@@ -51,15 +51,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ansi-styles": {
@@ -323,9 +314,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -657,15 +648,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -829,16 +811,16 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -849,12 +831,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -879,9 +860,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -1116,31 +1097,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1246,15 +1202,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/wordwrap": {
@@ -1451,18 +1398,18 @@
   },
   "dependencies": {
     "@toisu/middleware-runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.3.tgz",
-      "integrity": "sha512-KBiHpqBfynQyZP15f/EcbOrIlre71oo7yiogFyQGyzKk1wzm6R2SyU4dCbgwuYBl9B9ElamRe98lZDUi+jLo7g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.4.tgz",
+      "integrity": "sha512-A+nFnlOQm9a2r9r+ZloAJWXGbtjl0JonrPikXXf9MsdAgsCaSF5nBJd2bmcPYPa+8pmDy0sI/ritZAG5k2k3mA==",
       "dev": true
     },
     "@toisu/toisu": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.2.tgz",
-      "integrity": "sha512-tVVekluc0mscXOG4o9hJtHM9khR0gHyu3QKuwFQrWcv8L/3TnFnhWfyy+f3E6uhiubWqo+urimUCZQj/jVMTXw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.3.tgz",
+      "integrity": "sha512-5PEzEQ2Aw10BBXBbtWel1zP5AcCCPn5uCOJQZEMlYO/yFfXngB1UkLi+7+BMcQjxb620XHyxMLQ7gmSiHRSuXA==",
       "dev": true,
       "requires": {
-        "@toisu/middleware-runner": "^3.0.3"
+        "@toisu/middleware-runner": "^3.0.4"
       }
     },
     "@ungap/promise-all-settled": {
@@ -1475,12 +1422,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
@@ -1692,9 +1633,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -1927,12 +1868,6 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -2045,16 +1980,16 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -2065,12 +2000,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -2084,9 +2018,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "neo-async": {
@@ -2244,25 +2178,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      }
-    },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^3.0.0"
-      }
-    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2335,15 +2250,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
       }
     },
     "wordwrap": {

--- a/packages/handlebars/package.json
+++ b/packages/handlebars/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@toisu/toisu": "^4.0.3",
-    "mocha": "^9.0.3",
+    "mocha": "^9.1.2",
     "supertest": "^6.1.4"
   },
   "files": [],

--- a/packages/middleware-runner/package-lock.json
+++ b/packages/middleware-runner/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "@toisu/middleware-runner",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "devDependencies": {
-        "es2015-deferred": "^4.0.1",
-        "mocha": "^9.0.3",
-        "sinon": "^11.1.1"
+        "es2015-deferred": "^4.0.2",
+        "mocha": "^9.1.2",
+        "sinon": "^11.1.2"
       },
       "engines": {
         "node": ">=14"
@@ -238,9 +238,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -282,9 +282,9 @@
       "dev": true
     },
     "node_modules/es2015-deferred": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/es2015-deferred/-/es2015-deferred-4.0.1.tgz",
-      "integrity": "sha512-OHHEBqpBXuNetjqCyC6NBB2bAj6rBu4IaLxdAg1iCYYVN+x6SB1Vfv6qJFesPzQukqGgxDyoLuM+d+NYmUFglw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/es2015-deferred/-/es2015-deferred-4.0.2.tgz",
+      "integrity": "sha512-ryTcbP4E7b7Ad+5WZUIwQQsDk86CZ6G8KhoGJnBXXM4iuNZVUrKYO461JwARPHZxcZNEJSNtgUsTq3qbarjYaQ==",
       "dev": true
     },
     "node_modules/escalade": {
@@ -601,16 +601,16 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -621,12 +621,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -672,9 +671,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -843,13 +842,13 @@
       }
     },
     "node_modules/sinon": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/fake-timers": "^7.1.2",
         "@sinonjs/samsam": "^6.0.2",
         "diff": "^5.0.0",
         "nise": "^5.1.0",
@@ -944,58 +943,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/workerpool": {
@@ -1272,9 +1219,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -1299,9 +1246,9 @@
       "dev": true
     },
     "es2015-deferred": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/es2015-deferred/-/es2015-deferred-4.0.1.tgz",
-      "integrity": "sha512-OHHEBqpBXuNetjqCyC6NBB2bAj6rBu4IaLxdAg1iCYYVN+x6SB1Vfv6qJFesPzQukqGgxDyoLuM+d+NYmUFglw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/es2015-deferred/-/es2015-deferred-4.0.2.tgz",
+      "integrity": "sha512-ryTcbP4E7b7Ad+5WZUIwQQsDk86CZ6G8KhoGJnBXXM4iuNZVUrKYO461JwARPHZxcZNEJSNtgUsTq3qbarjYaQ==",
       "dev": true
     },
     "escalade": {
@@ -1527,16 +1474,16 @@
       }
     },
     "mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -1547,12 +1494,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -1583,9 +1529,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "nise": {
@@ -1701,13 +1647,13 @@
       }
     },
     "sinon": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/fake-timers": "^7.1.2",
         "@sinonjs/samsam": "^6.0.2",
         "diff": "^5.0.0",
         "nise": "^5.1.0",
@@ -1771,48 +1717,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "workerpool": {

--- a/packages/middleware-runner/package.json
+++ b/packages/middleware-runner/package.json
@@ -22,9 +22,9 @@
   "author": "Mark S. Everitt",
   "license": "MIT",
   "devDependencies": {
-    "es2015-deferred": "^4.0.1",
-    "mocha": "^9.0.3",
-    "sinon": "^11.1.1"
+    "es2015-deferred": "^4.0.2",
+    "mocha": "^9.1.2",
+    "sinon": "^11.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/router/package-lock.json
+++ b/packages/router/package-lock.json
@@ -6,17 +6,17 @@
   "packages": {
     "": {
       "name": "@toisu/router",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@toisu/middleware-runner": "^3.0.3",
+        "@toisu/middleware-runner": "^3.0.4",
         "path-to-regexp": "^6.2.0"
       },
       "devDependencies": {
-        "@toisu/toisu": "^4.0.2",
-        "mocha": "^9.0.3",
-        "sinon": "^11.1.1",
-        "supertest": "^6.1.4"
+        "@toisu/toisu": "^4.0.3",
+        "mocha": "^9.1.2",
+        "sinon": "^11.1.2",
+        "supertest": "^6.1.6"
       },
       "engines": {
         "node": ">=14"
@@ -58,20 +58,20 @@
       "dev": true
     },
     "node_modules/@toisu/middleware-runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.3.tgz",
-      "integrity": "sha512-KBiHpqBfynQyZP15f/EcbOrIlre71oo7yiogFyQGyzKk1wzm6R2SyU4dCbgwuYBl9B9ElamRe98lZDUi+jLo7g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.4.tgz",
+      "integrity": "sha512-A+nFnlOQm9a2r9r+ZloAJWXGbtjl0JonrPikXXf9MsdAgsCaSF5nBJd2bmcPYPa+8pmDy0sI/ritZAG5k2k3mA==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@toisu/toisu": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.2.tgz",
-      "integrity": "sha512-tVVekluc0mscXOG4o9hJtHM9khR0gHyu3QKuwFQrWcv8L/3TnFnhWfyy+f3E6uhiubWqo+urimUCZQj/jVMTXw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.3.tgz",
+      "integrity": "sha512-5PEzEQ2Aw10BBXBbtWel1zP5AcCCPn5uCOJQZEMlYO/yFfXngB1UkLi+7+BMcQjxb620XHyxMLQ7gmSiHRSuXA==",
       "dev": true,
       "dependencies": {
-        "@toisu/middleware-runner": "^3.0.3"
+        "@toisu/middleware-runner": "^3.0.4"
       },
       "engines": {
         "node": ">=14"
@@ -293,9 +293,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -527,15 +527,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -697,16 +688,16 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -717,12 +708,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -762,9 +752,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -962,13 +952,13 @@
       }
     },
     "node_modules/sinon": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/fake-timers": "^7.1.2",
         "@sinonjs/samsam": "^6.0.2",
         "diff": "^5.0.0",
         "nise": "^5.1.0",
@@ -1067,9 +1057,9 @@
       }
     },
     "node_modules/supertest": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.4.tgz",
-      "integrity": "sha512-giC9Zm+Bf1CZP09ciPdUyl+XlMAu6rbch79KYiYKOGcbK2R1wH8h+APul1i/3wN6RF1XfWOIF+8X1ga+7SBrug==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.6.tgz",
+      "integrity": "sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==",
       "dev": true,
       "dependencies": {
         "methods": "^1.1.2",
@@ -1134,49 +1124,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/workerpool": {
@@ -1315,17 +1262,17 @@
       "dev": true
     },
     "@toisu/middleware-runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.3.tgz",
-      "integrity": "sha512-KBiHpqBfynQyZP15f/EcbOrIlre71oo7yiogFyQGyzKk1wzm6R2SyU4dCbgwuYBl9B9ElamRe98lZDUi+jLo7g=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.4.tgz",
+      "integrity": "sha512-A+nFnlOQm9a2r9r+ZloAJWXGbtjl0JonrPikXXf9MsdAgsCaSF5nBJd2bmcPYPa+8pmDy0sI/ritZAG5k2k3mA=="
     },
     "@toisu/toisu": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.2.tgz",
-      "integrity": "sha512-tVVekluc0mscXOG4o9hJtHM9khR0gHyu3QKuwFQrWcv8L/3TnFnhWfyy+f3E6uhiubWqo+urimUCZQj/jVMTXw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.3.tgz",
+      "integrity": "sha512-5PEzEQ2Aw10BBXBbtWel1zP5AcCCPn5uCOJQZEMlYO/yFfXngB1UkLi+7+BMcQjxb620XHyxMLQ7gmSiHRSuXA==",
       "dev": true,
       "requires": {
-        "@toisu/middleware-runner": "^3.0.3"
+        "@toisu/middleware-runner": "^3.0.4"
       }
     },
     "@ungap/promise-all-settled": {
@@ -1505,9 +1452,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -1676,12 +1623,6 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -1798,16 +1739,16 @@
       }
     },
     "mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -1818,12 +1759,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -1851,9 +1791,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "nise": {
@@ -2005,13 +1945,13 @@
       }
     },
     "sinon": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/fake-timers": "^7.1.2",
         "@sinonjs/samsam": "^6.0.2",
         "diff": "^5.0.0",
         "nise": "^5.1.0",
@@ -2092,9 +2032,9 @@
       }
     },
     "supertest": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.4.tgz",
-      "integrity": "sha512-giC9Zm+Bf1CZP09ciPdUyl+XlMAu6rbch79KYiYKOGcbK2R1wH8h+APul1i/3wN6RF1XfWOIF+8X1ga+7SBrug==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.6.tgz",
+      "integrity": "sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==",
       "dev": true,
       "requires": {
         "methods": "^1.1.2",
@@ -2138,42 +2078,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "workerpool": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -26,9 +26,9 @@
   "license": "MIT",
   "devDependencies": {
     "@toisu/toisu": "^4.0.3",
-    "mocha": "^9.0.3",
-    "sinon": "^11.1.1",
-    "supertest": "^6.1.4"
+    "mocha": "^9.1.2",
+    "sinon": "^11.1.2",
+    "supertest": "^6.1.6"
   },
   "dependencies": {
     "@toisu/middleware-runner": "^3.0.4",

--- a/packages/static/package-lock.json
+++ b/packages/static/package-lock.json
@@ -6,16 +6,16 @@
   "packages": {
     "": {
       "name": "@toisu/static",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "serve-static": "^1.14.1"
       },
       "devDependencies": {
-        "@toisu/toisu": "^4.0.2",
-        "mocha": "^9.0.3",
-        "sinon": "^11.1.1",
-        "supertest": "^6.1.4"
+        "@toisu/toisu": "^4.0.3",
+        "mocha": "^9.1.2",
+        "sinon": "^11.1.2",
+        "supertest": "^6.1.6"
       },
       "engines": {
         "node": ">=14"
@@ -57,21 +57,21 @@
       "dev": true
     },
     "node_modules/@toisu/middleware-runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.3.tgz",
-      "integrity": "sha512-KBiHpqBfynQyZP15f/EcbOrIlre71oo7yiogFyQGyzKk1wzm6R2SyU4dCbgwuYBl9B9ElamRe98lZDUi+jLo7g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.4.tgz",
+      "integrity": "sha512-A+nFnlOQm9a2r9r+ZloAJWXGbtjl0JonrPikXXf9MsdAgsCaSF5nBJd2bmcPYPa+8pmDy0sI/ritZAG5k2k3mA==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@toisu/toisu": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.2.tgz",
-      "integrity": "sha512-tVVekluc0mscXOG4o9hJtHM9khR0gHyu3QKuwFQrWcv8L/3TnFnhWfyy+f3E6uhiubWqo+urimUCZQj/jVMTXw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.3.tgz",
+      "integrity": "sha512-5PEzEQ2Aw10BBXBbtWel1zP5AcCCPn5uCOJQZEMlYO/yFfXngB1UkLi+7+BMcQjxb620XHyxMLQ7gmSiHRSuXA==",
       "dev": true,
       "dependencies": {
-        "@toisu/middleware-runner": "^3.0.3"
+        "@toisu/middleware-runner": "^3.0.4"
       },
       "engines": {
         "node": ">=14"
@@ -679,15 +679,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -860,16 +851,16 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -880,12 +871,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -904,9 +894,9 @@
       }
     },
     "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -962,9 +952,9 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -1272,13 +1262,13 @@
       }
     },
     "node_modules/sinon": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/fake-timers": "^7.1.2",
         "@sinonjs/samsam": "^6.0.2",
         "diff": "^5.0.0",
         "nise": "^5.1.0",
@@ -1385,9 +1375,9 @@
       "dev": true
     },
     "node_modules/supertest": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.4.tgz",
-      "integrity": "sha512-giC9Zm+Bf1CZP09ciPdUyl+XlMAu6rbch79KYiYKOGcbK2R1wH8h+APul1i/3wN6RF1XfWOIF+8X1ga+7SBrug==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.6.tgz",
+      "integrity": "sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==",
       "dev": true,
       "dependencies": {
         "methods": "^1.1.2",
@@ -1457,49 +1447,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/workerpool": {
@@ -1684,18 +1631,18 @@
       "dev": true
     },
     "@toisu/middleware-runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.3.tgz",
-      "integrity": "sha512-KBiHpqBfynQyZP15f/EcbOrIlre71oo7yiogFyQGyzKk1wzm6R2SyU4dCbgwuYBl9B9ElamRe98lZDUi+jLo7g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.4.tgz",
+      "integrity": "sha512-A+nFnlOQm9a2r9r+ZloAJWXGbtjl0JonrPikXXf9MsdAgsCaSF5nBJd2bmcPYPa+8pmDy0sI/ritZAG5k2k3mA==",
       "dev": true
     },
     "@toisu/toisu": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.2.tgz",
-      "integrity": "sha512-tVVekluc0mscXOG4o9hJtHM9khR0gHyu3QKuwFQrWcv8L/3TnFnhWfyy+f3E6uhiubWqo+urimUCZQj/jVMTXw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@toisu/toisu/-/toisu-4.0.3.tgz",
+      "integrity": "sha512-5PEzEQ2Aw10BBXBbtWel1zP5AcCCPn5uCOJQZEMlYO/yFfXngB1UkLi+7+BMcQjxb620XHyxMLQ7gmSiHRSuXA==",
       "dev": true,
       "requires": {
-        "@toisu/middleware-runner": "^3.0.3"
+        "@toisu/middleware-runner": "^3.0.4"
       }
     },
     "@ungap/promise-all-settled": {
@@ -2160,12 +2107,6 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -2290,16 +2231,16 @@
       }
     },
     "mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -2310,12 +2251,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -2323,9 +2263,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -2368,9 +2308,9 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "nise": {
@@ -2592,13 +2532,13 @@
       }
     },
     "sinon": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/fake-timers": "^7.1.2",
         "@sinonjs/samsam": "^6.0.2",
         "diff": "^5.0.0",
         "nise": "^5.1.0",
@@ -2677,9 +2617,9 @@
       }
     },
     "supertest": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.4.tgz",
-      "integrity": "sha512-giC9Zm+Bf1CZP09ciPdUyl+XlMAu6rbch79KYiYKOGcbK2R1wH8h+APul1i/3wN6RF1XfWOIF+8X1ga+7SBrug==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.6.tgz",
+      "integrity": "sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==",
       "dev": true,
       "requires": {
         "methods": "^1.1.2",
@@ -2728,42 +2668,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "workerpool": {

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -22,9 +22,9 @@
   },
   "devDependencies": {
     "@toisu/toisu": "^4.0.3",
-    "mocha": "^9.0.3",
-    "sinon": "^11.1.1",
-    "supertest": "^6.1.4"
+    "mocha": "^9.1.2",
+    "sinon": "^11.1.2",
+    "supertest": "^6.1.6"
   },
   "dependencies": {
     "serve-static": "^1.14.1"

--- a/packages/toisu/package-lock.json
+++ b/packages/toisu/package-lock.json
@@ -6,23 +6,23 @@
   "packages": {
     "": {
       "name": "@toisu/toisu",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
-        "@toisu/middleware-runner": "^3.0.3"
+        "@toisu/middleware-runner": "^3.0.4"
       },
       "devDependencies": {
-        "mocha": "^9.0.3",
-        "supertest": "^6.1.4"
+        "mocha": "^9.1.2",
+        "supertest": "^6.1.6"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@toisu/middleware-runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.3.tgz",
-      "integrity": "sha512-KBiHpqBfynQyZP15f/EcbOrIlre71oo7yiogFyQGyzKk1wzm6R2SyU4dCbgwuYBl9B9ElamRe98lZDUi+jLo7g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.4.tgz",
+      "integrity": "sha512-A+nFnlOQm9a2r9r+ZloAJWXGbtjl0JonrPikXXf9MsdAgsCaSF5nBJd2bmcPYPa+8pmDy0sI/ritZAG5k2k3mA==",
       "engines": {
         "node": ">=14"
       }
@@ -256,9 +256,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -731,16 +731,16 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -751,12 +751,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -802,9 +801,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -1087,9 +1086,9 @@
       }
     },
     "node_modules/supertest": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.4.tgz",
-      "integrity": "sha512-giC9Zm+Bf1CZP09ciPdUyl+XlMAu6rbch79KYiYKOGcbK2R1wH8h+APul1i/3wN6RF1XfWOIF+8X1ga+7SBrug==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.6.tgz",
+      "integrity": "sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==",
       "dev": true,
       "dependencies": {
         "methods": "^1.1.2",
@@ -1142,58 +1141,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/workerpool": {
@@ -1297,9 +1244,9 @@
   },
   "dependencies": {
     "@toisu/middleware-runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.3.tgz",
-      "integrity": "sha512-KBiHpqBfynQyZP15f/EcbOrIlre71oo7yiogFyQGyzKk1wzm6R2SyU4dCbgwuYBl9B9ElamRe98lZDUi+jLo7g=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@toisu/middleware-runner/-/middleware-runner-3.0.4.tgz",
+      "integrity": "sha512-A+nFnlOQm9a2r9r+ZloAJWXGbtjl0JonrPikXXf9MsdAgsCaSF5nBJd2bmcPYPa+8pmDy0sI/ritZAG5k2k3mA=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -1483,9 +1430,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -1811,16 +1758,16 @@
       }
     },
     "mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -1831,12 +1778,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -1867,9 +1813,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "normalize-path": {
@@ -2063,9 +2009,9 @@
       }
     },
     "supertest": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.4.tgz",
-      "integrity": "sha512-giC9Zm+Bf1CZP09ciPdUyl+XlMAu6rbch79KYiYKOGcbK2R1wH8h+APul1i/3wN6RF1XfWOIF+8X1ga+7SBrug==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.6.tgz",
+      "integrity": "sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==",
       "dev": true,
       "requires": {
         "methods": "^1.1.2",
@@ -2103,48 +2049,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "workerpool": {

--- a/packages/toisu/package.json
+++ b/packages/toisu/package.json
@@ -15,8 +15,8 @@
   "author": "Mark S. Everitt",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^9.0.3",
-    "supertest": "^6.1.4"
+    "mocha": "^9.1.2",
+    "supertest": "^6.1.6"
   },
   "dependencies": {
     "@toisu/middleware-runner": "^3.0.4"


### PR DESCRIPTION
This pre-empts advisories around ansi-regex by bumping mocha to a version which no longer has it in its dependency tree. While I was in the dependencies I bumped everything else to keep things fresh.