### PR TITLE
Removes the globals module.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,11 +1,14 @@
-import globals from 'globals';
 import config from 'eslint-config-qubyte';
 
 export default [
   {
     languageOptions: {
       ...config.languageOptions,
-      globals: globals.nodeBuiltin
+      globals: {
+        Buffer: 'readable',
+        setTimeout: 'readable',
+        URL: 'readable'
+      }
     },
     rules: {
       ...config.rules,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
       "devDependencies": {
         "eslint": "^9.20.1",
         "eslint-config-qubyte": "^6.0.0",
-        "globals": "^15.15.0",
         "sinon": "^19.0.2",
         "supertest": "^7.0.0"
       }
@@ -3627,19 +3626,6 @@
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "eslint": "^9.20.1",
     "eslint-config-qubyte": "^6.0.0",
-    "globals": "^15.15.0",
     "sinon": "^19.0.2",
     "supertest": "^7.0.0"
   }


### PR DESCRIPTION
The globals module is used to tell ESLint about Node.js globals. The problem is, globals is updated frequently and that leads to a lot of dependabot toil. Since these packages use a small subset of well supported Node.js globals, I'm just listing them manually and dropping the globals module.